### PR TITLE
Display a simple map if applicable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ var/
 .env
 venv/
 .idea*
+*.iml

--- a/intialize_agent.py
+++ b/intialize_agent.py
@@ -23,6 +23,11 @@ def initialize(session_id: str):
             You are a helpful location aware agent.
             You search for things to do based on the context provided through the input.  
             Always Use the tools provided along with the context to provide the best answers to the human's questions.
+
+            Return your response as JSON object. The field `text` should contain
+            the text we should show to the user. If the tools give you a location or list of
+            locations that include a name and latitude and longitude values, add an
+            array field `locations` with items as objects with `name`, `lat`, and `lng` fields.
         """
     )
 

--- a/location_tools.py
+++ b/location_tools.py
@@ -32,23 +32,28 @@ def submit_request(endpoint: str, params: dict[str, str], version20241206: bool)
             #return "Lake Washington Park; Summit at Snoqualmie Skiing; Rocket Bowling", None
 
 @bedrock_agent_tool(action_group="LocationToolsActionGroup")
-def search_near(what: str, where: str=None) -> str:
+def search_near(what: str, where: str=None, ll: str=None, radius: int=1600) -> str:
     """Search for places near a particular named region or point. Either the
     region must be specified with the near parameter, or a circle around a point
     must be specified with the ll and radius parameters.
 
-    Always call me with a named region and not a latitude or longitude. If you have a latitude and longitude,
-    then call sn.
+    Call with either where or ll/radius, but not both.
 
     Args:
         what: concept you are looking for (e.g., coffee shop, Hard Rock Cafe)
         where: a geographic region (e.g., Los Angeles or Fort Greene), this must be a named region.
+        ll: comma separate latitude and longitude pair (e.g., 40.74,-74.0)
+        radius: radius in meters around the point specified by ll
     """
     params = {
         "query": what,
         "limit": 5,
-        "near": where
     }
+    if where:
+        params["near"] = where
+    if ll:
+        params["ll"] = ll
+        params["radius"] = radius
 
     return submit_request("/places/search", params, version20241206=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ langchain
 langgraph
 geocoder
 streamlit
-
+streamlit-folium


### PR DESCRIPTION
Here's where I'm at right now with map display.

Added requirement: streamlit-folium

I added ll and radius to the interface for search_near in location_tools, to allow searching either near a named region or in a radius around the latlng. I tried but failed to convince the LLM not to try to use actual non-geographic places for near (e.g., "find bars near the empire state building") and instead to look up that place first and then use a latlng query from there.

I updated the system prompt to request a structured response. It's possible we could make a `render_map` function instead, and pass information through some global state back to the renderer, which might encourage the LLM to be more descriptive in its direct response.

And I added a map_placeholder. We parse the location response from the LLM and then render the map using streamlit-folium.