### PR TITLE
Use tagged response

### DIFF
--- a/intialize_agent.py
+++ b/intialize_agent.py
@@ -22,12 +22,14 @@ def initialize(session_id: str):
         instructions="""
             You are a helpful location aware agent.
             You search for things to do based on the context provided through the input.  
-            Always Use the tools provided along with the context to provide the best answers to the human's questions.
+            Always Use the tools provided along with the context to provide the best answers
+            to the human's questions. Use the information from the tools to provide interesting
+            answers in a conversational style!
 
-            Return your response as JSON object. The field `text` should contain
-            the text we should show to the user. If the tools give you a location or list of
-            locations that include a name and latitude and longitude values, add an
-            array field `locations` with items as objects with `name`, `lat`, and `lng` fields.
+            Format your response using HTML, but whenever you identify a retrieved location by name, tag it
+            with the id, latitude and longitude: <place id="{{fsq_place_id}}" lat={{lat}} lng={{lng}}>{{name}}</place>
+
+            For example: `<div>Check out <place id="42893400f964a52052231fe3" lat=40.66193827120861 lng=-73.96961688995361>Prospect Park</place>, people say it's got great playgrounds!</div>`
         """
     )
 

--- a/location_tools.py
+++ b/location_tools.py
@@ -47,6 +47,7 @@ def search_near(what: str, where: str=None, ll: str=None, radius: int=1600) -> s
     """
     params = {
         "query": what,
+        "fields": "fsq_place_id,name,location,latitude,longitude,distance,description,hours,hours_popular,price,tips,tastes",
         "limit": 5,
     }
     if where:


### PR DESCRIPTION
After playing with this for a while, I had the best luck with:
1. requesting more rich data from places_search, including tips
2. instead of asking for two outputs, one structured and one unstructured, instead ask for a single output where the places are tagged, XML-style, with attributes for id, latitude, and longitude.

The rich data gives the LLM a lot more interesting information to work with, and it seems to produce richer and more natural responses (as opposed just listing place names alone or with simple data like rating or address) while also delivering the structured data necessary to render the map, when it focuses on a single output.

I left the json parsing function in there in case we want to switch back, though.